### PR TITLE
SlidingPaneLayout/foldable_largescreen

### DIFF
--- a/SlidingPaneLayout/app/build.gradle
+++ b/SlidingPaneLayout/app/build.gradle
@@ -29,6 +29,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -38,4 +41,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation "androidx.recyclerview:recyclerview:1.2.1"
+
+    implementation("androidx.slidingpanelayout:slidingpanelayout:1.2.0-beta01")
 }

--- a/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/ListItemsFragment.kt
+++ b/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/ListItemsFragment.kt
@@ -8,10 +8,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.cesarvaliente.slidingpanelayout.databinding.ListItemsLayoutBinding
 
 class ListItemsFragment() : Fragment() {
-
-    private lateinit var recyclerView: RecyclerView
+    private lateinit var binding: ListItemsLayoutBinding
     private lateinit var myAdapter: ItemsAdapter
     private lateinit var myViewManager: RecyclerView.LayoutManager
 
@@ -35,24 +35,15 @@ class ListItemsFragment() : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.list_items_layout, container, false)
+        binding = ListItemsLayoutBinding.inflate(inflater, container, false)
 
-        myAdapter = ItemsAdapter(dataset, ::onItemClickListener, sharedVM)
+        myAdapter = ItemsAdapter(dataset, sharedVM)
         myViewManager = LinearLayoutManager(requireContext())
-        recyclerView = view.findViewById<RecyclerView>(R.id.list_items).apply {
+        binding.listItems.apply {
             setHasFixedSize(true)
             layoutManager = myViewManager
             adapter = myAdapter
         }
-        return view
-    }
-
-    private fun onItemClickListener() {
-        activity?.run {
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, DetailFragment())
-                .addToBackStack("detailFragment")
-                .commit()
-        }
+        return binding.root
     }
 }

--- a/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/MainActivity.kt
+++ b/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/MainActivity.kt
@@ -1,16 +1,62 @@
 package com.cesarvaliente.slidingpanelayout
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.slidingpanelayout.widget.SlidingPaneLayout
+import com.cesarvaliente.slidingpanelayout.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
+    private val sharedVM: SharedVM by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.fragment_container, ListItemsFragment())
-            .commit()
+        onBackPressedDispatcher.addCallback(
+            this,
+            OnSlidingPaneLayoutBackPressedCallback(binding.slidingPaneLayout)
+        )
+
+        sharedVM.selectedItem.observe(this, Observer {
+            if (!binding.slidingPaneLayout.isOpen) {
+                binding.slidingPaneLayout.openPane()
+            }
+        })
+    }
+
+    inner class OnSlidingPaneLayoutBackPressedCallback(
+        private val slidingPaneLayout: SlidingPaneLayout
+    ) : OnBackPressedCallback(
+        slidingPaneLayout.isSlideable && slidingPaneLayout.isOpen
+    ), SlidingPaneLayout.PanelSlideListener {
+
+        init {
+            slidingPaneLayout.addPanelSlideListener(this)
+        }
+
+        override fun handleOnBackPressed() {
+            slidingPaneLayout.closePane()
+        }
+
+        override fun onPanelSlide(panel: View, slideOffset: Float) {
+            if (slideOffset > 0) {
+
+            }
+        }
+
+        override fun onPanelOpened(panel: View) {
+            isEnabled = true
+        }
+
+        override fun onPanelClosed(panel: View) {
+            isEnabled = false
+
+        }
     }
 }

--- a/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/recyclerview/ItemViewHolder.kt
+++ b/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/recyclerview/ItemViewHolder.kt
@@ -5,7 +5,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
-class ItemViewHolder(val view: View, val onClick: () -> Unit, val sharedVM: SharedVM) :
+class ItemViewHolder(view: View, val sharedVM: SharedVM) :
     RecyclerView.ViewHolder(view) {
     val layout: LinearLayout = itemView.findViewById(R.id.item_layout)
     val numberView: TextView = itemView.findViewById(R.id.item_number)

--- a/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/recyclerview/ItemsAdapter.kt
+++ b/SlidingPaneLayout/app/src/main/java/com/cesarvaliente/slidingpanelayout/recyclerview/ItemsAdapter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.RecyclerView
 
 class ItemsAdapter(
     private val items: Array<Item>,
-    private val onClick: () -> Unit,
     private val sharedVM: SharedVM
 ) : RecyclerView.Adapter<ItemViewHolder>() {
 
@@ -15,7 +14,7 @@ class ItemsAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.list_item, parent, false)
-        return ItemViewHolder(view, onClick, sharedVM)
+        return ItemViewHolder(view, sharedVM)
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
@@ -26,7 +25,6 @@ class ItemsAdapter(
             layout.setOnClickListener {
                 selectedItemPosition = position
                 sharedVM.setSelectedItem(item)
-                onClick()
                 notifyDataSetChanged()
             }
             changeItemBackground(position, selectedItemPosition, layout)
@@ -43,5 +41,7 @@ class ItemsAdapter(
 
     override fun getItemCount(): Int = items.size
 
-    fun getItem(position: Int): Item = items[position]
+    fun unSelectItem() {
+        selectedItemPosition = -1
+    }
 }

--- a/SlidingPaneLayout/app/src/main/res/layout/activity_main.xml
+++ b/SlidingPaneLayout/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+<androidx.slidingpanelayout.widget.SlidingPaneLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/sliding_pane_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <!-- The first child view becomes the left pane. When the combined
+    desired width (expressed using android:layout_width) would
+    not fit on-screen at once, the right pane is permitted to
+    overlap the left. -->
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:name="com.cesarvaliente.slidingpanelayout.ListItemsFragment"
+        android:layout_width="280dp"
+        android:layout_height="match_parent" />
+
+    <!-- The second child becomes the right (content) pane. In this
+    example, android:layout_weight is used to expand this detail pane
+    to consume leftover available space when the entire window is wide enough to fit both the left and right pane.-->
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/detail_container"
+        android:name="com.cesarvaliente.slidingpanelayout.DetailFragment"
+        android:layout_width="300dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1" />
+
+
+</androidx.slidingpanelayout.widget.SlidingPaneLayout>


### PR DESCRIPTION
This branch/PR handles the work related to the usage of `SlidingPaneLayout` in the app so it's enhanced for foldable and large screen devices.

Tasks:
- [x] Added `SlidingPaneLayout` dependency.
- [x] Using it already in code, and made the changes so it's used and shows both panes when on a large screen or foldable device.
- [ ] Fine tuning. There are a few issues that need to be solved as keeping the item selected when on Surface Duo we tap on an item and then we spann the app, and others that can be shown when playing with the app.   